### PR TITLE
Check nginx.conf exists before creating the backup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 start:
-	mv nginx.conf nginx.conf.bak
+	if [ -a nginx.conf ]; then mv nginx.conf nginx.conf.bak; fi;
 	python3 generate-conf.py
 	docker-compose up --build -d
 


### PR DESCRIPTION
The `make start` command failed the first time since the `ningx.conf` file did not exist and could therefore not be moved. 

Add just a small check before moving it so that the `make start` will work the first time as well 🚀 


I haven't tried the tool out much yet but it looks great and perfect for my use case! Ty Gurra