### PR TITLE
Add support for start/stop on a remote host using docker contexts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ start:
 ifdef context
 	docker-compose --context $(context) up --build --detach 
 else
+	docket context ls
 	docker-compose up --build --detach
 endif
 
@@ -11,5 +12,6 @@ stop:
 ifdef context
 	docker-compose --context $(context) stop
 else
+	docker-context ls
 	docker-compose stop
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
 start:
 	if [ -a nginx.conf ]; then mv nginx.conf nginx.conf.bak; fi;
 	python3 generate-conf.py
-	docker-compose up --build -d
+	ifdef context
+		docker-compose --context $(context) up --build --detach 
+	else
+		docker-compose up --build --detach
 
 stop:
-	docker-compose stop
-
+	ifdef context
+		docker-compose --context $(context) stop
+	else
+		docker-compose stop

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ start:
 ifdef context
 	docker-compose --context $(context) up --build --detach 
 else
-	docket context ls
+	docker context ls
 	docker-compose up --build --detach
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
 start:
 	if [ -a nginx.conf ]; then mv nginx.conf nginx.conf.bak; fi;
 	python3 generate-conf.py
-	ifdef context
-		docker-compose --context $(context) up --build --detach 
-	else
-		docker-compose up --build --detach
+ifdef context
+	docker-compose --context $(context) up --build --detach 
+else
+	docker-compose up --build --detach
+endif
 
 stop:
-	ifdef context
-		docker-compose --context $(context) stop
-	else
-		docker-compose stop
+ifdef context
+	docker-compose --context $(context) stop
+else
+	docker-compose stop
+endif

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,9 @@
 start:
 	if [ -a nginx.conf ]; then mv nginx.conf nginx.conf.bak; fi;
 	python3 generate-conf.py
-ifdef context
-	docker-compose --context $(context) up --build --detach 
-else
 	docker context ls
 	docker-compose up --build --detach
-endif
 
 stop:
-ifdef context
-	docker-compose --context $(context) stop
-else
 	docker-context ls
 	docker-compose stop
-endif

--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ This will generate a `nginx.conf` file for you and start the reverse proxy.
 
     make stop
 
+### Start/Stop on remote host
+
+To start or stop frontman on a remote host using [docker context](https://docs.docker.com/engine/context/working-with-contexts/), you can provide the optional parameter `context`:
+
+    docker context create my-server --docker "host=ssh://user@$my-server-ip"
+    make context=my-server start
+    make context=my-server stop
+
 ## Getting started on AWS EC2
 
 Launch a new Ubuntu image and set up security groups etc.


### PR DESCRIPTION
This makes it easier to start frontman on a remote server, e.g. from a CI/CD pipeline.

Note that the instructions in README does not explain how to use docker contexts in its entirely. To actually start frontman on a remote server using docker context, you'd also need to have ssh credentials configured in an ssh agent.